### PR TITLE
イベント登録機能 (shouldを利用して全てのバリデーションをテスト)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,8 @@ group :development, :test do
   gem 'rspec-rails'
 
   gem 'capybara'
+
+  gem 'shoulda-matchers', '~> 2.6.0'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,8 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    shoulda-matchers (2.6.2)
+      activesupport (>= 3.0.0)
     slop (3.6.0)
     spring (1.7.1)
     sprockets (3.6.0)
@@ -217,6 +219,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  shoulda-matchers (~> 2.6.0)
   spring
   sqlite3
   turbolinks

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,3 +1,3 @@
 class Event < ActiveRecord::Base
-  validates :name, presence: true
+  validates :name, length: { maximum: 50 }, presence: true
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,4 +4,15 @@ class Event < ActiveRecord::Base
   validates :content, length: { maximum: 200 }, presence: true
   validates :start_time, presence: true
   validates :end_time, presence: true
+  validate :start_time_should_be_before_end_time
+
+  private
+
+  def start_time_should_be_before_end_time
+    return unless start_time && end_time
+
+    if start_time >= end_time
+      errors.add(:start_time, 'は終了時間よりも前に設定してください')
+    end
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,4 +3,5 @@ class Event < ActiveRecord::Base
   validates :place, length: { maximum: 100  }, presence: true
   validates :content, length: { maximum: 200 }, presence: true
   validates :start_time, presence: true
+  validates :end_time, presence: true
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,5 @@
 class Event < ActiveRecord::Base
   validates :name, length: { maximum: 50 }, presence: true
-  validates :place, length: { maximum: 100  } ,presence: true
-  validates :content, presence: true
+  validates :place, length: { maximum: 100  }, presence: true
+  validates :content, length: { maximum: 200 }, presence: true
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,4 @@
 class Event < ActiveRecord::Base
   validates :name, length: { maximum: 50 }, presence: true
-  validates :place, presence: true
+  validates :place, length: { maximum: 100  } ,presence: true
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,5 @@
 class Event < ActiveRecord::Base
   validates :name, length: { maximum: 50 }, presence: true
   validates :place, length: { maximum: 100  } ,presence: true
+  validates :content, presence: true
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,4 +2,5 @@ class Event < ActiveRecord::Base
   validates :name, length: { maximum: 50 }, presence: true
   validates :place, length: { maximum: 100  }, presence: true
   validates :content, length: { maximum: 200 }, presence: true
+  validates :start_time, presence: true
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,7 +1,7 @@
 class Event < ActiveRecord::Base
   validates :name, length: { maximum: 50 }, presence: true
   validates :place, length: { maximum: 100  }, presence: true
-  validates :content, length: { maximum: 200 }, presence: true
+  validates :content, length: { maximum: 2000 }, presence: true
   validates :start_time, presence: true
   validates :end_time, presence: true
   validate :start_time_should_be_before_end_time

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,3 +1,4 @@
 class Event < ActiveRecord::Base
   validates :name, length: { maximum: 50 }, presence: true
+  validates :place, presence: true
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -8,5 +8,6 @@ describe Event, type: :model do
 
   describe '#place' do
     it { should validate_presence_of(:place) }
+    it { should ensure_length_of(:place).is_at_most(100) }
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -3,5 +3,6 @@ require 'rails_helper'
 describe Event, type: :model do
   describe '#name' do
     it { should validate_presence_of(:name) }
+    it { should ensure_length_of(:name).is_at_most(50) }
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -15,4 +15,8 @@ describe Event, type: :model do
     it { should validate_presence_of(:content) }
     it { should ensure_length_of(:content).is_at_most(200) }
   end
+
+  describe '#strat_time' do
+    it { should validate_presence_of(:start_time) }
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -2,39 +2,67 @@ require 'rails_helper'
 
 describe Event, type: :model do
   describe '#name' do
-    it { should validate_presence_of(:name) }
-    it { should ensure_length_of(:name).is_at_most(50) }
+    it '空白である時validationエラーとなる' do
+      should validate_presence_of(:name)
+    end
+
+    it '50文字以上の時validationエラーとなる' do
+      should ensure_length_of(:name).is_at_most(50)
+    end
   end
 
   describe '#place' do
-    it { should validate_presence_of(:place) }
-    it { should ensure_length_of(:place).is_at_most(100) }
+    it '空白である時validationエラーとなる' do
+      should validate_presence_of(:place)
+    end
+
+    it '100文字以上の時validationエラーとなる' do
+      should ensure_length_of(:place).is_at_most(100)
+    end
   end
 
   describe '#content' do
-    it { should validate_presence_of(:content) }
-    it { should ensure_length_of(:content).is_at_most(2000) }
+    it '空白である時validationエラーとなる' do
+      validate_presence_of(:content)
+    end
+
+    it '100文字以上の時validationエラーとなる' do
+      should ensure_length_of(:content).is_at_most(2000)
+    end
   end
 
   describe '#strat_time' do
-    it { should validate_presence_of(:start_time) }
+    it '空白である時validationエラーとなる' do
+      should validate_presence_of(:start_time)
+    end
   end
 
   describe '#end_time' do
-    it { should validate_presence_of(:end_time) }
+    it '空白である時validationエラーとなる' do
+      should validate_presence_of(:end_time)
+    end
   end
 
-  describe 'start_time と end_time の相関関係について' do
-    context 'start_time と end_time を比べた時' do
-      it 'start_timeの方が早い時(正常系)' do
+  describe 'start_time が end_time' do
+    context 'より早い時' do
+      it '正常に動作する' do
         event = Event.new(start_time: Time.local(2015, 5, 20, 23, 59, 59), end_time: Time.local(2015, 5, 21, 23, 59, 59))
         event.valid?
         expect(event.errors[:start_time]).to be_blank
       end
+    end
+    context 'と同じ時' do
+      it 'validationエラーとなる' do
+        event = Event.new(start_time: Time.local(2015, 5, 21, 23, 59, 59), end_time: Time.local(2015, 5, 21, 23, 59, 59))
+        event.valid?
+        expect(event.errors[:start_time]).to be_present
+      end
+    end
 
-      it 'start_time の方が遅い時' do
+    context 'より遅い時' do
+      it 'validationエラーとなる' do
         event = Event.new(start_time: Time.local(2015, 5, 21, 23, 59, 59), end_time: Time.local(2015, 5, 20, 23, 59, 59))
-        event.save
+        event.valid?
         expect(event.errors[:start_time]).to be_present
       end
     end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -2,13 +2,6 @@ require 'rails_helper'
 
 describe Event, type: :model do
   describe '#name' do
-    context '空白のとき' do
-      let(:event) { Event.new(name: '') }
-
-      it 'validでないこと' do
-        event.valid?
-        expect(event.errors[:name]).to be_present
-      end
-    end
+    it { should validate_presence_of(:name) }
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -10,4 +10,8 @@ describe Event, type: :model do
     it { should validate_presence_of(:place) }
     it { should ensure_length_of(:place).is_at_most(100) }
   end
+
+  describe '#content' do
+    it { should validate_presence_of(:content) }
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -19,4 +19,8 @@ describe Event, type: :model do
   describe '#strat_time' do
     it { should validate_presence_of(:start_time) }
   end
+
+  describe '#end_time' do
+    it { should validate_presence_of(:end_time) }
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -26,6 +26,12 @@ describe Event, type: :model do
 
   describe 'start_time と end_time の相関関係について' do
     context 'start_time と end_time を比べた時' do
+      it 'strat_timeの方が早い時(正常系)' do
+        event = Event.new(start_time: Time.local(2015, 5, 20, 23, 59, 59), end_time: Time.local(2015, 5, 21, 23, 59, 59))
+        event.valid?
+        expect(event.errors[:start_time]).to be_blank
+      end
+
       it 'strat_time の方が遅い時' do
         event = Event.new(start_time: Time.local(2015, 5, 21, 23, 59, 59), end_time: Time.local(2015, 5, 20, 23, 59, 59))
         event.save

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -13,7 +13,7 @@ describe Event, type: :model do
 
   describe '#content' do
     it { should validate_presence_of(:content) }
-    it { should ensure_length_of(:content).is_at_most(200) }
+    it { should ensure_length_of(:content).is_at_most(2000) }
   end
 
   describe '#strat_time' do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -5,4 +5,8 @@ describe Event, type: :model do
     it { should validate_presence_of(:name) }
     it { should ensure_length_of(:name).is_at_most(50) }
   end
+
+  describe '#place' do
+    it { should validate_presence_of(:place) }
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -26,13 +26,13 @@ describe Event, type: :model do
 
   describe 'start_time と end_time の相関関係について' do
     context 'start_time と end_time を比べた時' do
-      it 'strat_timeの方が早い時(正常系)' do
+      it 'start_timeの方が早い時(正常系)' do
         event = Event.new(start_time: Time.local(2015, 5, 20, 23, 59, 59), end_time: Time.local(2015, 5, 21, 23, 59, 59))
         event.valid?
         expect(event.errors[:start_time]).to be_blank
       end
 
-      it 'strat_time の方が遅い時' do
+      it 'start_time の方が遅い時' do
         event = Event.new(start_time: Time.local(2015, 5, 21, 23, 59, 59), end_time: Time.local(2015, 5, 20, 23, 59, 59))
         event.save
         expect(event.errors[:start_time]).to be_present

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -13,5 +13,6 @@ describe Event, type: :model do
 
   describe '#content' do
     it { should validate_presence_of(:content) }
+    it { should ensure_length_of(:content).is_at_most(200) }
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -23,4 +23,14 @@ describe Event, type: :model do
   describe '#end_time' do
     it { should validate_presence_of(:end_time) }
   end
+
+  describe '#start_time_should_be_before_end_time' do
+    context 'start_timeの方がend_timeを比べた時' do
+      it 'strat_timeの方が遅い時' do
+        event = Event.new(start_time: Time.local(2015, 5, 21, 23, 59, 59), end_time: Time.local(2015, 5, 20, 23, 59, 59))
+        event.save
+        expect(event.errors[:start_time]).to be_present
+      end
+    end
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -24,9 +24,9 @@ describe Event, type: :model do
     it { should validate_presence_of(:end_time) }
   end
 
-  describe '#start_time_should_be_before_end_time' do
-    context 'start_timeの方がend_timeを比べた時' do
-      it 'strat_timeの方が遅い時' do
+  describe 'start_time と end_time の相関関係について' do
+    context 'start_time と end_time を比べた時' do
+      it 'strat_time の方が遅い時' do
         event = Event.new(start_time: Time.local(2015, 5, 21, 23, 59, 59), end_time: Time.local(2015, 5, 20, 23, 59, 59))
         event.save
         expect(event.errors[:start_time]).to be_present


### PR DESCRIPTION
## やったこと
#8 の続き
+ Eventモデルの全属性に対して以下のバリデーションを設定
   + name,place,start_time,end_time,contentの記入は必須
   + nameは50文字以下
   + placeは100文字以下
   + contentは2000文字以下
   + start_timeはend_timeよりも前の時間
+ それぞれに対してテストを作成

## 動作確認
+ [x] `rspec spec//models/event_spec.rb`が通る

## マージ条件
+ [x] #8がマージされていること