### PR TITLE
 p.196〜 イベント編集画面

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -31,6 +31,12 @@ class EventsController < ApplicationController
   end
 
   def update
+    @event = current_user.created_events.find(params[:id])
+    if @event.update(event_params)
+      redirect_to @event, notice: '更新しました'
+    else
+      render :edit
+    end
   end
 
   private

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -22,6 +22,9 @@ class EventsController < ApplicationController
     end
   end
 
+  def edit
+  end
+
   private
 
   def event_params

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -30,6 +30,9 @@ class EventsController < ApplicationController
     end
   end
 
+  def update
+  end
+
   private
 
   def event_params

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -23,6 +23,11 @@ class EventsController < ApplicationController
   end
 
   def edit
+    begin
+      @event = current_user.created_events.find(params[:id])
+    rescue
+      redirect_to root_path, notice: 'そのイベントは存在しません'
+    end
   end
 
   private

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,6 +8,11 @@ class Event < ActiveRecord::Base
   validates :end_time, presence: true
   validate :start_time_should_be_before_end_time
 
+  def created_by?(user)
+    return false unless user
+    owner_id == user.id
+  end
+
   private
 
   def start_time_should_be_before_end_time

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,0 +1,41 @@
+<% now = Time.zone.now %>
+<div class="page-header">
+  <h1>イベント編集</h1>
+</div>
+
+<%= form_for(@event, class: 'form-horizontal', role: 'form') do |f| %>
+  <% if @event.errors.any? %>
+  <div class="alert alert-denger">
+    <ul>
+      <% @event.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+  <% end %>
+  <div class="form-group">
+    <%= f.label :name %>
+    <%= f.text_field :name, class: 'form-control' %>
+  </div>
+  <div class="form-group">
+    <%= f.label :place %>
+    <%= f.text_field :place, class: 'form-control' %>
+  </div>
+  <div class="form-group">
+    <%= f.label :start_time %>
+    <div>
+      <%= f.datetime_select :start_time, start_year: now.year, end_year: now.year + 1 %>
+    </div>
+  </div>
+  <div class="form-group">
+    <%= f.label :end_time %>
+    <div>
+      <%= f.datetime_select :end_time, start_year: now.year, end_year: now.year + 1 %>
+    </div>
+  </div>
+  <div class="form-group">
+    <%= f.label :content %>
+    <%= f.text_area :content, class: 'form-control', row: 10 %>
+  </div>
+  <%= f.submit '更新', class: 'btn btn-default', data: { disable_with: '更新中...' } %>
+<% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -4,41 +4,49 @@
   </h1>
 </div>
 
-<div class="panel panel-default">
-  <div class="panel-heading">
-    主催者
+<div class="row">
+  <div class="col-md-8">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        主催者
+      </div>
+      <div class="panel-body">
+        <%= link_to("https://twitter.com/#{@event.owner.nickname}") do %>
+          <%= image_tag @event.owner.image_url %>
+          <%= "@#{@event.owner.nickname}" %>
+        <% end %>
+      </div>
+    </div>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        開催時間
+      </div>
+      <div class="panel-body">
+        <%= @event.start_time.strftime('%Y/%m/%d %H:%M') %> - <%= @event.end_time.strftime('%Y/%m/%d %H:%M') %>
+      </div>
+    </div>
+
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        開催場所
+      </div>
+      <div class="panel-body">
+        <%= @event.place %>
+      </div>
+    </div>
+
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        イベント内容
+      </div>
+      <div class="panel-body">
+        <%= @event.content %>
+      </div>
+    </div>
   </div>
-  <div class="panel-body">
-    <%= link_to("https://twitter.com/#{@event.owner.nickname}") do %>
-      <%= image_tag @event.owner.image_url %>
-      <%= "@#{@event.owner.nickname}" %>
+  <div class="col-md-4">
+    <% if @event.created_by?(current_user) %>
+      <%= link_to 'イベントを編集する', edit_event_path(@event), class: 'btn btn-info btn-lg btn-block' %>
     <% end %>
-  </div>
-</div>
-
-<div class="panel panel-default">
-  <div class="panel-heading">
-    開催時間
-  </div>
-  <div class="panel-body">
-    <%= @event.start_time.strftime('%Y/%m/%d %H:%M') %> - <%= @event.end_time.strftime('%Y/%m/%d %H:%M') %>
-  </div>
-</div>
-
-<div class="panel panel-default">
-  <div class="panel-heading">
-    開催場所
-  </div>
-  <div class="panel-body">
-    <%= @event.place %>
-  </div>
-</div>
-
-<div class="panel panel-default">
-  <div class="panel-heading">
-    イベント内容
-  </div>
-  <div class="panel-body">
-    <%= @event.content %>
   </div>
 </div>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -2,15 +2,24 @@
   <h1>イベント一覧</h1>
 </div>
 
-<div class="list-group">
+<div class="row">
   <% @events.each do |event| %>
-    <%= link_to(event, class: 'list-group-item') do %>
-      <h4 class="list-group-item-heading">
-        <%= event.name %>
-      </h4>
-      <p class="list-group-item-text">
-        <%= event.start_time.strftime('%Y/%m/%d/%H:%M') %> - <%= event.end_time.strftime('%Y/%m/%d/%H:%M') %>
-      </p>
+  <div class="col-md-8">
+      <div class="list-group">
+      <%= link_to(event, class: 'list-group-item') do %>
+        <h4 class="list-group-item-heading">
+          <%= event.name %>
+        </h4>
+        <p class="list-group-item-text">
+          <%= event.start_time.strftime('%Y/%m/%d/%H:%M') %> - <%= event.end_time.strftime('%Y/%m/%d/%H:%M') %>
+        </p>
+      <% end %>
+    </div>
+  </div>
+  <div class="col-md-4">
+    <% if event.created_by?(current_user) %>
+      <%= link_to '編集', edit_event_path(event), class: 'btn btn-info btn-lg btn-block' %>
     <% end %>
+  </div>
   <% end %>
 </div>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -4,22 +4,22 @@
 
 <div class="row">
   <% @events.each do |event| %>
-  <div class="col-md-8">
+    <div class="col-md-8">
       <div class="list-group">
-      <%= link_to(event, class: 'list-group-item') do %>
-        <h4 class="list-group-item-heading">
-          <%= event.name %>
-        </h4>
-        <p class="list-group-item-text">
-          <%= event.start_time.strftime('%Y/%m/%d/%H:%M') %> - <%= event.end_time.strftime('%Y/%m/%d/%H:%M') %>
-        </p>
-      <% end %>
+        <%= link_to(event, class: 'list-group-item') do %>
+          <h4 class="list-group-item-heading">
+            <%= event.name %>
+          </h4>
+          <p class="list-group-item-text">
+            <%= event.start_time.strftime('%Y/%m/%d/%H:%M') %> - <%= event.end_time.strftime('%Y/%m/%d/%H:%M') %>
+          </p>
+        <% end %>
+      </div>
     </div>
-  </div>
-  <div class="col-md-4">
     <% if event.created_by?(current_user) %>
-      <%= link_to '編集', edit_event_path(event), class: 'btn btn-info btn-lg btn-block' %>
+      <div class="col-md-4">
+        <%= link_to '編集', edit_event_path(event), class: 'btn btn-info btn-lg btn-block' %>
+      </div>
     <% end %>
-  </div>
   <% end %>
 </div>

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -172,6 +172,7 @@ describe EventsController do
       before do
         session[:user_id] = user.id
       end
+
       context 'かつ、パラメータに不備がある時' do
         let(:params) do
           {

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -165,14 +165,13 @@ describe EventsController do
   end
 
   describe 'PATCH #update' do
-    let!(:user) { create(:user) }
-    let!(:event) { create(:future_event, owner_id: user.id) }
-
-    before do
-      session[:user_id] = user.id
-    end
-
     context 'ログインユーザが主催者のイベント編集ページで更新ボタンが押された時' do
+      let!(:user) { create(:user) }
+      let!(:event) { create(:future_event, owner_id: user.id) }
+
+      before do
+        session[:user_id] = user.id
+      end
       context 'かつ、パラメータに不備がある時' do
         let(:params) do
           {
@@ -190,37 +189,37 @@ describe EventsController do
           expect(response).to render_template :edit
         end
       end
-    end
 
-    context 'かつ正しいパラメータが入っている時' do
-      let(:params) do
-        {
-          id: event.id,
-          owner_id: event.owner_id,
-          name: "update event name",
-          place: "update event place",
-          content: "update event context",
-          start_time: DateTime.new(event.start_time.year,1,1,00,00),
-          end_time: DateTime.new(event.end_time.year,1,1,01,00)
-        }
-      end
+      context 'かつ正しいパラメータが入っている時' do
+        let(:params) do
+          {
+            id: event.id,
+            owner_id: event.owner_id,
+            name: "update event name",
+            place: "update event place",
+            content: "update event context",
+            start_time: DateTime.new(event.start_time.year,1,1,00,00),
+            end_time: DateTime.new(event.end_time.year,1,1,01,00)
+          }
+        end
 
-      before do
-        patch :update, {id: event.id, event: params}
-      end
+        before do
+          patch :update, {id: event.id, event: params}
+        end
 
-      it '各パラメータが正しく格納されていること' do
-        updated_event = Event.find(event.id)
-        expect(updated_event.id).to eq params[:id]
-        expect(updated_event.owner_id).to eq params[:owner_id]
-        expect(updated_event.name).to eq params[:name]
-        expect(updated_event.place).to eq params[:place]
-        expect(updated_event.start_time).to eq params[:start_time]
-        expect(updated_event.end_time).to eq params[:end_time]
-      end
+        it '各パラメータが正しく格納されていること' do
+          updated_event = Event.find(event.id)
+          expect(updated_event.id).to eq params[:id]
+          expect(updated_event.owner_id).to eq params[:owner_id]
+          expect(updated_event.name).to eq params[:name]
+          expect(updated_event.place).to eq params[:place]
+          expect(updated_event.start_time).to eq params[:start_time]
+          expect(updated_event.end_time).to eq params[:end_time]
+        end
 
-      it 'show テンプレートをrender していること' do
-        expect(response).to redirect_to event_path
+        it 'show テンプレートをrender していること' do
+          expect(response).to redirect_to event_path
+        end
       end
     end
   end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -135,4 +135,27 @@ describe EventsController do
       end
     end
   end
+
+  describe 'GET #edit' do
+    context 'ログインユーザが主催者でないイベント編集ページにアクセスした時' do
+      it 'トップページにリダイレクトすること'
+    end
+
+    context 'ログインユーザが主催者のイベント編集ページにアクセスした時' do
+      it '@event のedit テンプレートをrender していること'
+    end
+  end
+
+  describe 'PATCH #update' do
+    context 'ログインユーザが主催者のイベント編集ページにアクセスした時' do
+      context 'かつパラメータ不足している時' do
+        it '@event のedit テンプレートをrender していること'
+      end
+
+      context 'かつ正しいパラメータが入っている時' do
+        it 'イベントが更新できていること'
+        it 'show テンプレートをrender していること'
+      end
+    end
+  end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -144,7 +144,7 @@ describe EventsController do
 
       before do
         session[:user_id] = other_user.id
-        get :edit, id: 1
+        get :edit, id: user_event.id
       end
 
       it 'トップページにリダイレクトすること' do
@@ -165,8 +165,8 @@ describe EventsController do
   end
 
   describe 'PATCH #update' do
-    let(:user) { create(:user) }
-    let(:event) { create(:future_event) }
+    let!(:user) { create(:user) }
+    let!(:event) { create(:future_event, owner_id: user.id) }
 
     before do
       session[:user_id] = user.id
@@ -195,15 +195,13 @@ describe EventsController do
     context 'かつ正しいパラメータが入っている時' do
       let(:params) do
         {
-          event:{
-            id: event.id,
-            owner_id: event.owner_id,
-            name: "update event name",
-            place: "update event place",
-            context: "update event context",
-            start_time: DateTime.new(event.start_time.year,1,1,00,00),
-            end_time: DateTime.new(event.end_time.year,1,1,01,00)
-          }
+          id: event.id,
+          owner_id: event.owner_id,
+          name: "update event name",
+          place: "update event place",
+          content: "update event context",
+          start_time: DateTime.new(event.start_time.year,1,1,00,00),
+          end_time: DateTime.new(event.end_time.year,1,1,01,00)
         }
       end
 
@@ -213,16 +211,16 @@ describe EventsController do
 
       it '各パラメータが正しく格納されていること' do
         updated_event = Event.find(event.id)
-        expect(updated_event.id).to eq params[:event][:id]
-        expect(updated_event.owner_id).to eq params[:event][:owner_id]
-        expect(updated_event.name).to eq params[:event][:name]
-        expect(updated_event.place).to eq params[:event][:place]
-        expect(updated_event.start_time).to eq params[:event][:start_time]
-        expect(updated_event.end_time).to eq params[:event][:end_time]
+        expect(updated_event.id).to eq params[:id]
+        expect(updated_event.owner_id).to eq params[:owner_id]
+        expect(updated_event.name).to eq params[:name]
+        expect(updated_event.place).to eq params[:place]
+        expect(updated_event.start_time).to eq params[:start_time]
+        expect(updated_event.end_time).to eq params[:end_time]
       end
 
       it 'show テンプレートをrender していること' do
-        expect(response).to render_template :show
+        expect(response).to redirect_to event_path
       end
     end
   end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -137,12 +137,32 @@ describe EventsController do
   end
 
   describe 'GET #edit' do
+    let(:user) { create(:user)}
+
     context 'ログインユーザが主催者でないイベント編集ページにアクセスした時' do
-      it 'トップページにリダイレクトすること'
+      let(:other_event) { create(:future_event)}
+
+      before do
+        session[:user_id] = other_event.owner_id
+        get :edit, id: other_event.id
+      end
+
+      it 'トップページにリダイレクトすること' do
+        expect(response).to redirect_to(root_path)
+      end
     end
 
     context 'ログインユーザが主催者のイベント編集ページにアクセスした時' do
-      it '@event のedit テンプレートをrender していること'
+      let(:user_event) { create(:future_event, owner_id: user.id) }
+
+      before do
+        session[:user_id] = user.id
+        get :edit, id: user_event.id
+      end
+
+      it '@event のedit テンプレートをrender していること' do
+        expect(response).to render_template :edit, id: user_event.id
+      end
     end
   end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -120,7 +120,7 @@ describe EventsController do
         end
 
         it 'show テンプレートをrender していること' do
-          expect(response).to render_template :show
+          expect(response).to render_template :show, id: event.id
         end
       end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -138,13 +138,14 @@ describe EventsController do
 
   describe 'GET #edit' do
     let(:user) { create(:user)}
+    let(:user_event) { create(:future_event, owner_id: user.id) }
 
     context 'ログインユーザが主催者でないイベント編集ページにアクセスした時' do
-      let(:other_event) { create(:future_event)}
+      let(:other_user) { create(:user)}
 
       before do
-        session[:user_id] = other_event.owner_id
-        get :edit, id: other_event.id
+        session[:user_id] = other_user.id
+        get :edit, id: 1
       end
 
       it 'トップページにリダイレクトすること' do
@@ -153,8 +154,6 @@ describe EventsController do
     end
 
     context 'ログインユーザが主催者のイベント編集ページにアクセスした時' do
-      let(:user_event) { create(:future_event, owner_id: user.id) }
-
       before do
         session[:user_id] = user.id
         get :edit, id: user_event.id

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -176,16 +176,14 @@ describe EventsController do
       context 'かつ、パラメータに不備がある時' do
         let(:params) do
           {
-            event:{
               name: "大事な会議",
               start_time: DateTime.new(event.start_time.year,6,3,13,00),
               end_time: DateTime.new(event.start_time.year - 1,6,3,12,00) #=> 1年前に変更。
-            }
           }
         end
 
         before do
-          patch :update, params
+          patch :update, {id: event.id, event: params}
         end
 
         it '@event のedit テンプレートをrender していること' do
@@ -210,7 +208,7 @@ describe EventsController do
       end
 
       before do
-        patch :update, params
+        patch :update, {id: event.id, event: params}
       end
 
       it '各パラメータが正しく格納されていること' do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -120,7 +120,7 @@ describe EventsController do
         end
 
         it 'show テンプレートをrender していること' do
-          expect(response).to render_template :show, id: event.id
+          expect(response).to render_template :show
         end
       end
 
@@ -161,7 +161,7 @@ describe EventsController do
       end
 
       it '@event のedit テンプレートをrender していること' do
-        expect(response).to render_template :edit, id: user_event.id
+        expect(response).to render_template :edit
       end
     end
   end

--- a/spec/features/edit_events_spec.rb
+++ b/spec/features/edit_events_spec.rb
@@ -6,8 +6,8 @@ RSpec.feature "EditEvent", type: :feature do
     let(:user_event) { create(:future_event, owner_id: user.id) }
 
     before do
-      ApplicationController.any_instance.stub(:current_user).and_return(user)
-      ApplicationController.any_instance.stub(:logged_in?).and_return(true)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      allow_any_instance_of(ApplicationController).to receive(:logged_in?).and_return(true)
       visit event_path(id: user_event.id)
       click_link 'イベントを編集する'
     end

--- a/spec/features/edit_events_spec.rb
+++ b/spec/features/edit_events_spec.rb
@@ -1,6 +1,24 @@
 require 'rails_helper'
 
 RSpec.feature "EditEvent", type: :feature do
+  describe '「編集」ボタン以外の方法でイベント編集ページにアクセスした時' do
+    let(:event) { create(:future_event) }
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:logged_in?).and_return(true)
+      visit edit_event_path(id: event.id)
+    end
+
+    context 'かつ、ログインユーザがそのイベントの主催者でない時' do
+      it 'トップページに遷移すること' do
+        expect(page).to have_content /イベント一覧/
+      end
+
+      it '「そのイベントは存在しません」が表示されていること' do
+        expect(page).to have_content /そのイベントは存在しません/
+      end
+    end
+  end
+
   describe '詳細画面で、ユーザが"イベントを編集する"をクリックした時' do
     let(:user) { create(:user) }
     let(:user_event) { create(:future_event, owner_id: user.id) }

--- a/spec/features/edit_events_spec.rb
+++ b/spec/features/edit_events_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.feature "EditEvent", type: :feature do
+  describe '詳細画面で、ユーザが"イベントを編集する"をクリックした時' do
+    let(:user) { create(:user) }
+    let(:user_event) { create(:future_event, owner_id: user.id) }
+
+    before do
+      ApplicationController.any_instance.stub(:current_user).and_return(user)
+      ApplicationController.any_instance.stub(:logged_in?).and_return(true)
+      visit event_path(id: user_event.id)
+      click_link 'イベントを編集する'
+    end
+
+    it 'イベント編集画面に遷移すること' do
+      expect(page.current_path).to eq edit_event_path(id: user_event.id)
+    end
+
+    context 'かつ、更新ボタンを押した時に、イベントの属性に不備があった時' do
+      before do
+        fill_in "event_name", with: "テストイベント"
+        fill_in "event_place", with: "テスト開催場所"
+        fill_in "event_content", with: "テスト説明文"
+        select '2017', from: 'event_start_time_1i'
+        select '9月', from: 'event_start_time_2i'
+        select '10', from: 'event_start_time_3i'
+        select '00', from: 'event_start_time_4i'
+        select '00', from: 'event_start_time_5i'
+        select "#{user_event.start_time.year - 1}", from: 'event_end_time_1i'
+        select '9月', from: 'event_end_time_2i'
+        select '11', from: 'event_end_time_3i'
+        select '00', from: 'event_end_time_4i'
+        select '00', from: 'event_end_time_5i'
+        click_button '更新'
+      end
+
+      it 'イベント編集画面に遷移すること' do
+        expect(page.current_path).to eq edit_event_path(id: user_event.id)
+      end
+
+      it 'エラーの内容が表示されていること' do
+        expect(page).to have_content /開始時間は終了時間よりも前に設定してください/
+      end
+    end
+
+    context 'かつ、作成ボタンを押した時に、不備なくイベントの属性が入力されている時' do
+      before do
+        fill_in "event_name", with: "テストイベント"
+        fill_in "event_place", with: "テスト開催場所"
+        fill_in "event_content", with: "テスト説明文"
+        select '2017', from: 'event_start_time_1i'
+        select '9月', from: 'event_start_time_2i'
+        select '10', from: 'event_start_time_3i'
+        select '00', from: 'event_start_time_4i'
+        select '00', from: 'event_start_time_5i'
+        select '2017', from: 'event_end_time_1i'
+        select '9月', from: 'event_end_time_2i'
+        select '11', from: 'event_end_time_3i'
+        select '00', from: 'event_end_time_4i'
+        select '00', from: 'event_end_time_5i'
+        click_button '更新'
+      end
+
+      it '更新したイベントの詳細ぺージに遷移していること' do
+        expect(page.current_path).to eq event_path(id: user_event.id)
+      end
+
+      it '"更新しました"というアラートが表示されること' do
+        expect(page).to have_content /更新しました/
+      end
+    end
+  end
+end

--- a/spec/features/edit_events_spec.rb
+++ b/spec/features/edit_events_spec.rb
@@ -12,10 +12,6 @@ RSpec.feature "EditEvent", type: :feature do
       click_link 'イベントを編集する'
     end
 
-    it 'イベント編集画面に遷移すること' do
-      expect(page.current_path).to eq edit_event_path(id: user_event.id)
-    end
-
     context 'かつ、更新ボタンを押した時に、イベントの属性に不備があった時' do
       before do
         fill_in "event_name", with: "テストイベント"
@@ -32,10 +28,6 @@ RSpec.feature "EditEvent", type: :feature do
         select '00', from: 'event_end_time_4i'
         select '00', from: 'event_end_time_5i'
         click_button '更新'
-      end
-
-      it 'イベント編集画面に遷移すること' do
-        expect(page.current_path).to eq edit_event_path(id: user_event.id)
       end
 
       it 'エラーの内容が表示されていること' do
@@ -59,10 +51,6 @@ RSpec.feature "EditEvent", type: :feature do
         select '00', from: 'event_end_time_4i'
         select '00', from: 'event_end_time_5i'
         click_button '更新'
-      end
-
-      it '更新したイベントの詳細ぺージに遷移していること' do
-        expect(page.current_path).to eq event_path(id: user_event.id)
       end
 
       it '"更新しました"というアラートが表示されること' do

--- a/spec/features/edit_events_spec.rb
+++ b/spec/features/edit_events_spec.rb
@@ -12,6 +12,10 @@ RSpec.feature "EditEvent", type: :feature do
       click_link 'イベントを編集する'
     end
 
+    it 'イベント編集画面に遷移すること' do
+      expect(page).to have_content /イベント編集/
+    end
+
     context 'かつ、更新ボタンを押した時に、イベントの属性に不備があった時' do
       before do
         fill_in "event_name", with: "テストイベント"
@@ -28,6 +32,10 @@ RSpec.feature "EditEvent", type: :feature do
         select '00', from: 'event_end_time_4i'
         select '00', from: 'event_end_time_5i'
         click_button '更新'
+      end
+
+      it 'イベント編集画面に遷移すること' do
+        expect(page).to have_content /イベント編集/
       end
 
       it 'エラーの内容が表示されていること' do
@@ -51,6 +59,10 @@ RSpec.feature "EditEvent", type: :feature do
         select '00', from: 'event_end_time_4i'
         select '00', from: 'event_end_time_5i'
         click_button '更新'
+      end
+
+      it '更新したイベントの詳細ぺージに遷移していること' do
+        expect(page).to have_content /テストイベント/
       end
 
       it '"更新しました"というアラートが表示されること' do

--- a/spec/views/events/show.html.erb_spec.rb
+++ b/spec/views/events/show.html.erb_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe "events/show", type: :view do
     it '選択されたEvent のイベント内容が表示されていること' do
       expect(rendered).to match(/#{event.content}/)
     end
+
+    context '選択されたEvent の主催者がログインユーザの時' do
+      it '"イベントを編集する"が表示されていること'
+    end
+
+    context '選択されたEvent の主催者がログインユーザ以外の時' do
+      it '"イベントを編集する"が表示されていないこと'
+    end
   end
 
   context '存在しないページにユーザがアクセスした時' do

--- a/spec/views/events/show.html.erb_spec.rb
+++ b/spec/views/events/show.html.erb_spec.rb
@@ -2,11 +2,21 @@ require "rails_helper"
 
 RSpec.describe "events/show", type: :view do
   context '存在するページにユーザがアクセスした時' do
+    before do
+      def view.logged_in?
+      end
+
+      def view.current_user
+      end
+    end
+
     context '選択されたEvent の主催者がログインユーザの時' do
       let(:user) { create(:user) }
       let(:user_event) { create(:future_event, owner_id: user.id) }
 
       before do
+        allow(view).to receive(:logged_in?) { true }
+        allow(view).to receive(:current_user) { user }
         session[:user_id] = user.id
         assign(:event, user_event)
         render
@@ -43,13 +53,14 @@ RSpec.describe "events/show", type: :view do
       let(:other_event) { create(:future_event, owner_id: other_user.id) }
 
       before do
-        session[:user_id] = other_user.id
+        allow(view).to receive(:logged_in?) { false }
+        allow(view).to receive(:current_user) { nil }
         assign(:event, other_event)
         render
       end
 
       it '選択されたEvent のイベント名が表示されていること' do
-        expect(rendered).to match(/#{ohter_event.name}/)
+        expect(rendered).to match(/#{other_event.name}/)
       end
 
       it '選択されたEvent の主催者名が表示されていること' do

--- a/spec/views/events/show.html.erb_spec.rb
+++ b/spec/views/events/show.html.erb_spec.rb
@@ -2,38 +2,34 @@ require "rails_helper"
 
 RSpec.describe "events/show", type: :view do
   context '存在するページにユーザがアクセスした時' do
-    let(:event) { create(:future_event) }
-    before do
-      assign(:event, event)
-      render
-    end
-
-    it '選択されたEvent のイベント名が表示されていること' do
-      expect(rendered).to match(/#{event.name}/)
-    end
-
-    it '選択されたEvent の主催者名が表示されていること' do
-      expect(rendered).to match(/@#{User.find(event.owner_id).nickname}/)
-    end
-
-    it '選択されたEvent の開催時間が表示されていること' do
-      expect(rendered).to match(/#{event.start_time.strftime('%Y/%m/%d %H:%M')} - #{event.end_time.strftime('%Y/%m/%d %H:%M')}/)
-    end
-
-    it '選択されたEvent の開催場所が表示されていること' do
-      expect(rendered).to match(/#{event.place}/)
-    end
-
-    it '選択されたEvent のイベント内容が表示されていること' do
-      expect(rendered).to match(/#{event.content}/)
-    end
-
     context '選択されたEvent の主催者がログインユーザの時' do
       let(:user) { create(:user) }
       let(:user_event) { create(:future_event, owner_id: user.id) }
 
       before do
         session[:user_id] = user.id
+        assign(:event, user_event)
+        render
+      end
+
+      it '選択されたEvent のイベント名が表示されていること' do
+        expect(rendered).to match(/#{user_event.name}/)
+      end
+
+      it '選択されたEvent の主催者名が表示されていること' do
+        expect(rendered).to match(/@#{User.find(user_event.owner_id).nickname}/)
+      end
+
+      it '選択されたEvent の開催時間が表示されていること' do
+        expect(rendered).to match(/#{user_event.start_time.strftime('%Y/%m/%d %H:%M')} - #{user_event.end_time.strftime('%Y/%m/%d %H:%M')}/)
+      end
+
+      it '選択されたEvent の開催場所が表示されていること' do
+        expect(rendered).to match(/#{user_event.place}/)
+      end
+
+      it '選択されたEvent のイベント内容が表示されていること' do
+        expect(rendered).to match(/#{user_event.content}/)
       end
 
       it '"イベントを編集する"が表示されていること' do
@@ -42,11 +38,34 @@ RSpec.describe "events/show", type: :view do
     end
 
     context '選択されたEvent の主催者がログインユーザ以外の時' do
+      let(:user) { create(:user) }
       let(:other_user) { create(:user) }
-      let(:other_event) { create(:future_event, owner_id: other_user.id + 1) }
+      let(:other_event) { create(:future_event, owner_id: other_user.id) }
 
       before do
         session[:user_id] = other_user.id
+        assign(:event, other_event)
+        render
+      end
+
+      it '選択されたEvent のイベント名が表示されていること' do
+        expect(rendered).to match(/#{ohter_event.name}/)
+      end
+
+      it '選択されたEvent の主催者名が表示されていること' do
+        expect(rendered).to match(/@#{User.find(other_event.owner_id).nickname}/)
+      end
+
+      it '選択されたEvent の開催時間が表示されていること' do
+        expect(rendered).to match(/#{other_event.start_time.strftime('%Y/%m/%d %H:%M')} - #{other_event.end_time.strftime('%Y/%m/%d %H:%M')}/)
+      end
+
+      it '選択されたEvent の開催場所が表示されていること' do
+        expect(rendered).to match(/#{other_event.place}/)
+      end
+
+      it '選択されたEvent のイベント内容が表示されていること' do
+        expect(rendered).to match(/#{other_event.content}/)
       end
 
       it '"イベントを編集する"が表示されていないこと' do

--- a/spec/views/events/show.html.erb_spec.rb
+++ b/spec/views/events/show.html.erb_spec.rb
@@ -29,11 +29,29 @@ RSpec.describe "events/show", type: :view do
     end
 
     context '選択されたEvent の主催者がログインユーザの時' do
-      it '"イベントを編集する"が表示されていること'
+      let(:user) { create(:user) }
+      let(:user_event) { create(:future_event, owner_id: user.id) }
+
+      before do
+        session[:user_id] = user.id
+      end
+
+      it '"イベントを編集する"が表示されていること' do
+        expect(rendered).to match(/イベントを編集する/)
+      end
     end
 
     context '選択されたEvent の主催者がログインユーザ以外の時' do
-      it '"イベントを編集する"が表示されていないこと'
+      let(:other_user) { create(:user) }
+      let(:other_event) { create(:future_event, owner_id: other_user.id + 1) }
+
+      before do
+        session[:user_id] = other_user.id
+      end
+
+      it '"イベントを編集する"が表示されていないこと' do
+        expect(rendered).not_to match(/イベントを編集する/)
+      end
     end
   end
 

--- a/spec/views/welcome/index.html.erb_spec.rb
+++ b/spec/views/welcome/index.html.erb_spec.rb
@@ -1,5 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe "welcome/index", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context 'ログインユーザがアクセスした時' do
+    it 'まだ開催していないイベント一覧が表示されている'
+
+    context 'ログインユーザが作成したイベントが存在するとき' do
+      it 'そのイベントに対する「編集」ボタンが表示されている'
+    end
+  end
 end

--- a/spec/views/welcome/index.html.erb_spec.rb
+++ b/spec/views/welcome/index.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "welcome/index", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/welcome/index.html.erb_spec.rb
+++ b/spec/views/welcome/index.html.erb_spec.rb
@@ -2,10 +2,42 @@ require 'rails_helper'
 
 RSpec.describe "welcome/index", type: :view do
   context 'ログインユーザがアクセスした時' do
-    it 'まだ開催していないイベント一覧が表示されている'
 
-    context 'ログインユーザが作成したイベントが存在するとき' do
-      it 'そのイベントに対する「編集」ボタンが表示されている'
-    end
+      let(:user) { create(:user) }
+      let(:other_user) { create(:user) }
+      let(:user_events) { create_list(:future_event, 5, owner_id: user.id) }
+      let(:other_events) { create_list(:future_event, 5, owner_id: other_user.id) }
+
+      before do
+        def view.logged_in?
+        end
+
+        def view.current_user
+        end
+
+        allow(view).to receive(:logged_in?) { true }
+        allow(view).to receive(:current_user) { user }
+        session[:user_id] = user.id
+        assign(:events, user_events + other_events)
+        render
+      end
+
+      it 'まだ開催していないイベント一覧が表示されている' do
+        user_events.each do |event|
+          expect(rendered).to match(/#{ event.name }/)
+        end
+
+        other_events.each do |event|
+          expect(rendered).to match(/#{ event.name }/)
+        end
+      end
+
+      context 'ログインユーザが作成したイベントが存在するとき' do
+        it 'そのイベントに対する「編集」ボタンが表示されている' do
+          user_events.each do |event|
+            expect(rendered).to match(/<a class=\"btn btn-info btn-lg btn-block\" href=\"\/events\/#{event.id}\/edit\">編集<\/a>/)
+          end
+        end
+      end
   end
 end


### PR DESCRIPTION
## やること
+ [x] イベント詳細ページに「イベントを編集する」リンクを追加
  + [x] イベントを作成したユーザがアクセスした時だけ表示
+ [x] トップページにイベントに対応した「編集」リンクを追加
+ [x] 「イベントを編集する」をクリックすると、イベント編集フォームに遷移する
+ [x] イベント編集フォームで間違った入力をするとイベントがエラーメッセージが表示される